### PR TITLE
Changed method for stripping datetime

### DIFF
--- a/Standalone_Windows_Log_Parser.py
+++ b/Standalone_Windows_Log_Parser.py
@@ -133,9 +133,9 @@ def backup_logs(logs):
 #           EventDate     
 ################################################################################
 def is_off_hours(EventDate):
-    dt = datetime.datetime.strptime(EventDate[:-4],
+    dt = datetime.datetime.strptime(EventDate[0:19],
                 '%Y-%m-%dT%H:%M:%S')
-    dd = datetime.datetime.strptime(EventDate[:-13],
+    dd = datetime.datetime.strptime(EventDate[0:10],
                 '%Y-%m-%d')            
     if dt.isoweekday() not in range(1,6) or dt.hour not in range(7,18
                 ) or dd in holidays:


### PR DESCRIPTION
Changed method for stripping datetime, in order to accommodate different possible return values. For example, on Windows 10 Pro 21H2 running python 3.10.2, I'm seeing a returned datetime format of '2022-03-15T12:59:19.8460000Z', which was previously resulting in an error because the incorrect number of characters were getting stripped off the end.